### PR TITLE
Crypt::PRNG does not provide a VERSION

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
     'MIME::Base64' => 0,
     'Time::HiRes'  => 0,
     'Carp'         => 0,
-    'Crypt::PRNG'  => '0.021',
+    'CryptX'       => '0.021',
   },
   BUILD_REQUIRES => {
     'FindBin'         => 0,


### PR DESCRIPTION
Unfortunately Crypt::PRNG does not provide a VERSION. This is why installation of Mojolicious::Plugin::OAuth2::Server fails:

```
==> Found dependencies: Crypt::PRNG, Test::Exception
Searching Crypt::PRNG on cpanmetadb ...
Found Crypt::PRNG  which doesn't satisfy 0.021.
...
-> FAIL Installing the dependencies failed: Module 'Crypt::PRNG' is not installed
-> FAIL Bailing out the installation for Mojolicious-Plugin-OAuth2-Server-0.07.
```
