### PR TITLE
Allow all valid characters in client credentials

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2/Server.pm
+++ b/lib/Mojolicious/Plugin/OAuth2/Server.pm
@@ -587,7 +587,7 @@ sub _client_credentials_from_header {
   if ( my $auth_header = $self->req->headers->header( 'Authorization' ) ) {
     if ( my ( $encoded_details ) = ( split( 'Basic ',$auth_header ) )[1] ) {
       my $decoded_details = b64_decode( $encoded_details // '' );
-      ( $client_id,$client_secret ) = split( ':',$decoded_details );
+      ( $client_id,$client_secret ) = split( ':',$decoded_details, 2);
       return ( $client_id,$client_secret );
     }
 

--- a/t/011_secrets.t
+++ b/t/011_secrets.t
@@ -1,0 +1,34 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Mojolicious::Lite;
+use Test::More;
+use Test::Mojo;
+use Encode qw( encode );
+use Mojo::Util qw( b64_encode );
+
+# Based on VSCHAR definition in RFC 6749
+my $secret = encode('UTF-8', join('', map { chr } 0x20 .. 0x7e));
+
+MOJO_APP: {
+  # plugin configuration
+  plugin 'OAuth2::Server' => {
+    clients => {
+      boo => {
+        client_secret => $secret,
+        scopes => {},
+      },
+    },
+  };
+};
+
+my $t = Test::Mojo->new;
+$t->post_ok(
+  "/oauth/access_token",
+  { Authorization => "Basic @{[ b64_encode(qq{boo:$secret}, '') ]}" },
+  form => { grant_type => 'client_credentials' }
+)->status_is(200);
+
+done_testing;


### PR DESCRIPTION
RFC 6749 specifies that the client_secret can contain any ASCII character between 0x20 and 0x7e, including the colon (":").